### PR TITLE
fix: typo and minor improvements

### DIFF
--- a/cmd/storoku/template/deploy/Makefile
+++ b/cmd/storoku/template/deploy/Makefile
@@ -61,11 +61,9 @@ clean-shared:
 
 clean: clean-terraform clean-shared
 
-.PHONY: app/.terraform
 app/.terraform:
 	TF_WORKSPACE=default tofu -chdir=app init -backend-config="key=storacha/$(TF_VAR_app)/terraform.tfstate"
 
-.PHONY: shared/.terraform
 shared/.terraform:
 	TF_WORKSPACE=default tofu -chdir=shared init -backend-config="key=storacha/$(TF_VAR_app)/shared.tfstate"
 

--- a/cmd/storoku/template/deploy/Makefile
+++ b/cmd/storoku/template/deploy/Makefile
@@ -23,7 +23,7 @@ eval_image_tag:
 
 get_env_file = ENV_FILE = $$(abspath .env.production.local)
 
-.PHONE: eval_env_file
+.PHONY: eval_env_file
 eval_env_file: .env.production.local
 	$(eval $(get_env_file))
 
@@ -61,9 +61,11 @@ clean-shared:
 
 clean: clean-terraform clean-shared
 
+.PHONY: app/.terraform
 app/.terraform:
-	tofu -chdir=app init -backend-config="key=storacha/$(TF_VAR_app)/terraform.tfstate"
+	TF_WORKSPACE=default tofu -chdir=app init -backend-config="key=storacha/$(TF_VAR_app)/terraform.tfstate"
 
+.PHONY: shared/.terraform
 shared/.terraform:
 	TF_WORKSPACE=default tofu -chdir=shared init -backend-config="key=storacha/$(TF_VAR_app)/shared.tfstate"
 

--- a/deployment/codedeploy.tf
+++ b/deployment/codedeploy.tf
@@ -33,6 +33,7 @@ aws --version
 echo "Constructing deployment command..."
 COMMAND=$(cat <<EOT
 aws deploy create-deployment \
+    --region "${data.aws_region.current.name}" \
     --application-name "${aws_codedeploy_app.app.name}" \
     --deployment-config-name CodeDeployDefault.ECSAllAtOnce \
     --deployment-group-name "${aws_codedeploy_deployment_group.deployment_group.deployment_group_name}" \


### PR DESCRIPTION
when I ran `make init` from my clean environment as the first step to deploy my dev env, I was presented with a message from `tofu init` because I had `TF_WORKSPACE=vic` in my `.env.terraform` file but the workspace didn't exist yet. I think the solution is to force `TF_WORKSPACE=default` in the init for the `app` folder too, as is done with the `shared` folder.

I also added `.PHONY` targets for the init tasks so that they are always run. There are some situations where modules need to be updated and a new init is required.