### PR TITLE
fix: allow additional actions on DynamoDB tables

### DIFF
--- a/deployment/ecs_task.tf
+++ b/deployment/ecs_task.tf
@@ -256,8 +256,14 @@ data "aws_iam_policy_document" "task_dynamodb_put_get_document" {
 
   statement {
     actions = [
+      "dynamodb:Query",
+      "dynamodb:Scan",
+      "dynamodb:BatchWriteItem",
       "dynamodb:GetItem",
       "dynamodb:PutItem",
+      "dynamodb:UpdateItem",
+      "dynamodb:DeleteItem",
+      "dynamodb:DescribeTable",
     ]
     resources = [for k, table in var.tables : table.arn]
   }


### PR DESCRIPTION
Add more actions to what tasks can do on DynamoDB tables.

I think the added actions are general enough to fit most use cases, but if we don't want to allow them by default I can also add a new flag to the `table add` command to add them only when requested.