### PR TITLE
fix: move key to backend block

### DIFF
--- a/cmd/storoku/template/deploy/Makefile
+++ b/cmd/storoku/template/deploy/Makefile
@@ -66,10 +66,10 @@ clean-shared:
 clean: clean-terraform clean-shared
 
 app/.terraform:
-	TF_WORKSPACE=default tofu -chdir=app init -backend-config="key=storacha/$(TF_VAR_app)/terraform.tfstate"
+	TF_WORKSPACE=default tofu -chdir=app init
 
 shared/.terraform:
-	TF_WORKSPACE=default tofu -chdir=shared init -backend-config="key=storacha/$(TF_VAR_app)/shared.tfstate"
+	TF_WORKSPACE=default tofu -chdir=shared init
 
 .tfworkspace:
 	tofu -chdir=app workspace new $(TF_WORKSPACE) 
@@ -82,12 +82,12 @@ init: app/.terraform shared/.terraform .tfworkspace
 .PHONY: upgrade-shared
 
 upgrade-shared:
-	TF_WORKSPACE=default tofu -chdir=shared init --upgrade -backend-config="key=storacha/$(TF_VAR_app)/shared.tfstate"
+	TF_WORKSPACE=default tofu -chdir=shared init --upgrade
 
 .PHONY: upgrade-app
 
 upgrade-app: upgrade-shared
-	tofu -chdir=app init -upgrade -backend-config="key=storacha/$(TF_VAR_app)/terraform.tfstate"
+	tofu -chdir=app init -upgrade
 
 .PHONY: upgrade
 upgrade: upgrade-shared upgrade-app

--- a/cmd/storoku/template/deploy/app/main.tf
+++ b/cmd/storoku/template/deploy/app/main.tf
@@ -10,6 +10,7 @@ terraform {
   }
   backend "s3" {
     bucket = "storacha-terraform-state"
+    key = "storacha/${var.app}/terraform.tfstate"
     region = "us-west-2"
     encrypt = true
   }

--- a/cmd/storoku/template/deploy/shared/main.tf
+++ b/cmd/storoku/template/deploy/shared/main.tf
@@ -11,7 +11,7 @@ terraform {
   }
   backend "s3" {
     bucket = "storacha-terraform-state"
-   
+    key = "storacha/${var.app}/shared.tfstate"
     region = "us-west-2"
     encrypt = true
   }


### PR DESCRIPTION
I thought vars couldn't be used in the main terraform block, but I tested it in the indexer and IPNI repos and it works as expected and it's easier to read.