### PR TITLE
feat: additional env vars available for task

### DIFF
--- a/app/deployment.tf
+++ b/app/deployment.tf
@@ -23,6 +23,7 @@ module "deployment" {
     database = local.db_database
   }
   caches = local.caches
+  cache_user_id = local.cache_user_id
   queues = module.queues
   tables = module.tables
   topics = module.topics

--- a/app/deployment.tf
+++ b/app/deployment.tf
@@ -7,6 +7,7 @@ module "deployment" {
   lb_security_group = module.ecs_infra.lb_security_group
   app = var.app
   environment = var.environment
+  public_url = local.domain.name
   env_vars = local.env_vars
   ecs_cluster = module.ecs_infra.ecs_cluster
   kms = local.kms

--- a/app/locals.tf
+++ b/app/locals.tf
@@ -8,6 +8,7 @@ locals {
   vpc = local.dedicated_resources ? module.vpc[0] : data.terraform_remote_state.shared.outputs.dev_vpc
   buckets = var.buckets 
   caches = local.dedicated_resources ? length(var.caches) > 0 ? module.caches[0].caches : {} : try(data.terraform_remote_state.shared.outputs.dev_caches.caches, {})
+  cache_user_id = local.dedicated_resources ? length(var.caches) > 0 ? module.caches[0].iam_user.user_id : "" : try(data.terraform_remote_state.shared.outputs.dev_caches.iam_user.user_id, "")
   database = local.dedicated_resources ? var.create_db ? module.databases[0].database : null : try(data.terraform_remote_state.shared.outputs.dev_databases.database, null)
   
   # Network and domain configuration

--- a/deployment/ecs_task.tf
+++ b/deployment/ecs_task.tf
@@ -45,6 +45,10 @@ resource "aws_ecs_task_definition" "app" {
         startPeriod = 10
       } : null
       environment = concat(var.env_vars,
+        [{
+            name = "PUBLIC_URL"
+            value = var.public_url
+        }],
         [for key, cache in var.caches : {
           name = "${upper(key)}_CACHE_ID"
           value = cache.id

--- a/deployment/ecs_task.tf
+++ b/deployment/ecs_task.tf
@@ -53,6 +53,12 @@ resource "aws_ecs_task_definition" "app" {
           name = "${upper(key)}_CACHE_URL"
           value = "${cache.address}:${cache.port}"
         }],
+        length(var.caches) > 0 ? [
+          {
+            name = "CACHE_USER_ID"
+            value = var.cache_user_id
+          }
+        ] : [],
         var.create_db ? [
           {
             name = "PGHOST"

--- a/deployment/ecs_task.tf
+++ b/deployment/ecs_task.tf
@@ -93,6 +93,10 @@ resource "aws_ecs_task_definition" "app" {
           name = "${upper(key)}_BUCKET_NAME"
           value = bucket.bucket
         }],
+        [ for key, bucket in var.buckets : {
+          name = "${upper(key)}_BUCKET_REGIONAL_DOMAIN"
+          value = bucket.regional_domain_name
+        }],
         [ for key, queue in var.queues : {
           name = "${upper(key)}_QUEUE_ID"
           value = queue.id

--- a/deployment/variables.tf
+++ b/deployment/variables.tf
@@ -8,6 +8,10 @@ variable "environment" {
   type        = string
 }
 
+variable "public_url" {
+  type = string
+}
+
 variable "kms" {
   description = "id of a KMS key used to encrypt"
   type = object({

--- a/deployment/variables.tf
+++ b/deployment/variables.tf
@@ -140,6 +140,7 @@ variable "buckets" {
   type = map(object({
     arn = string
     bucket = string
+    regional_domain_name = string
   }))
 }
 

--- a/deployment/variables.tf
+++ b/deployment/variables.tf
@@ -128,6 +128,10 @@ variable "caches" {
   }))
 }
 
+variable "cache_user_id" {
+  type = string
+}
+
 variable "buckets" {
   type = map(object({
     arn = string

--- a/s3/outputs.tf
+++ b/s3/outputs.tf
@@ -5,3 +5,7 @@ output "bucket" {
 output "arn" {
   value = aws_s3_bucket.bucket.arn
 }
+
+output "regional_domain_name" {
+  value = aws_s3_bucket.bucket.bucket_regional_domain_name
+}


### PR DESCRIPTION
ref: https://github.com/storacha/indexing-service/issues/224

Add some more environment variables that may be useful for the task:
- `CACHE_USER_ID`
- `PUBLIC_URL`
- `<BUCKET_NAME>_BUCKET_REGIONAL_DOMAIN`

I'm adding these because they are used by the indexing service.