### PR TITLE
feat: configurable message retention for queues

### DIFF
--- a/app/sqs.tf
+++ b/app/sqs.tf
@@ -5,4 +5,5 @@ module "queues" {
   environment = var.environment
   name = each.key
   fifo = each.value.fifo
+  message_retention_seconds = each.value.message_retention_seconds
 }

--- a/app/variables.tf
+++ b/app/variables.tf
@@ -72,6 +72,7 @@ variable "queues" {
   type = list(object({
     name = string
     fifo = optional(bool, false)
+    message_retention_seconds = optional(number, 0)
   }))
   default = []
 }

--- a/cmd/storoku/main.go
+++ b/cmd/storoku/main.go
@@ -330,8 +330,9 @@ func (c CompiledJS) AsTask() string {
 }
 
 type Queue struct {
-	Name string `json:"name"`
-	Fifo bool   `json:"fifo"`
+	Name                    string `json:"name"`
+	Fifo                    bool   `json:"fifo"`
+	MessageRetentionSeconds int    `json:"messageRetentionSeconds,omitempty"`
 }
 
 type Bucket struct {

--- a/cmd/storoku/queue.go
+++ b/cmd/storoku/queue.go
@@ -29,6 +29,11 @@ var queueAddCmd = &cli.Command{
 			Value:       false,
 			DefaultText: "specify if the queue will be fifo",
 		},
+		&cli.IntFlag{
+			Name:        "msg-retention-seconds",
+			Value:       0,
+			DefaultText: "message retention period in seconds (default: 345600 (4 days), min: 60 (1 min), max: 1209600 (14 days))",
+		},
 	},
 	Action: modifyAndRegenerate(func(ctx context.Context, cmd *cli.Command, c *Config) error {
 		queueName := cmd.StringArg("queue")
@@ -41,10 +46,22 @@ var queueAddCmd = &cli.Command{
 			}
 		}
 		fifo := cmd.Bool("fifo")
-		c.Queues = append(c.Queues, Queue{
-			Name: queueName,
-			Fifo: fifo,
-		})
+		retention := cmd.Int("msg-retention-seconds")
+
+		// Validate retention period
+		if retention != 0 {
+			if retention < 60 || retention > 1209600 {
+				return errors.New("message retention must be between 60 seconds (1 min) and 1209600 seconds (14 days)")
+			}
+		}
+
+		queue := Queue{
+			Name:                    queueName,
+			Fifo:                    fifo,
+			MessageRetentionSeconds: retention,
+		}
+
+		c.Queues = append(c.Queues, queue)
 		return nil
 	}),
 }

--- a/cmd/storoku/template/deploy/app/main.tf
+++ b/cmd/storoku/template/deploy/app/main.tf
@@ -74,8 +74,8 @@ module "app" {
   queues = [{{range .Queues}}
     {
       name = "{{ .Name }}"
-      fifo = {{ .Fifo }}
-      message_retention_seconds = {{ .MessageRetentionSeconds }}
+      fifo = {{ .Fifo }}{{if .MessageRetentionSeconds}}
+      message_retention_seconds = {{ .MessageRetentionSeconds }}{{end}}
     },
   {{end}}]
   caches = [{{range .Caches}}"{{.}}",{{end}}]

--- a/cmd/storoku/template/deploy/app/main.tf
+++ b/cmd/storoku/template/deploy/app/main.tf
@@ -75,6 +75,7 @@ module "app" {
     {
       name = "{{ .Name }}"
       fifo = {{ .Fifo }}
+      message_retention_seconds = {{ .MessageRetentionSeconds }}
     },
   {{end}}]
   caches = [{{range .Caches}}"{{.}}",{{end}}]

--- a/sqs/main.tf
+++ b/sqs/main.tf
@@ -4,6 +4,7 @@ resource "aws_sqs_queue" "queue" {
   fifo_queue = var.fifo
   content_based_deduplication = var.fifo ? true : null
   visibility_timeout_seconds = !var.fifo ? 300 : null
+  message_retention_seconds = var.message_retention_seconds > 0 ? var.message_retention_seconds : null
   redrive_policy = jsonencode({
     deadLetterTargetArn = aws_sqs_queue.queue_deadletter.arn
     maxReceiveCount     = 4

--- a/sqs/variables.tf
+++ b/sqs/variables.tf
@@ -18,3 +18,14 @@ variable "fifo" {
   type        = bool
   default = false
 }
+
+variable "message_retention_seconds" {
+  description = "The number of seconds Amazon SQS retains a message. Integer representing seconds, from 60 (1 minute) to 1209600 (14 days)."
+  type        = number
+  default     = 0
+
+  validation {
+    condition     = var.message_retention_seconds == 0 || (var.message_retention_seconds >= 60 && var.message_retention_seconds <= 1209600)
+    error_message = "The message_retention_seconds value must be between 60 and 1209600 seconds (14 days), or 0 to use the default (345600 seconds/4 days)."
+  }
+}


### PR DESCRIPTION
ref: https://github.com/storacha/indexing-service/issues/224

Allow specifying message retention for SQS queues.

I tested the changes in the branch of the indexing-service I'm currently working on.