### PR TITLE
fix: add cache user to cache connect policy

### DIFF
--- a/app/deployment.tf
+++ b/app/deployment.tf
@@ -24,7 +24,7 @@ module "deployment" {
     database = local.db_database
   }
   caches = local.caches
-  cache_user_id = local.cache_user_id
+  cache_user = local.cache_user
   queues = module.queues
   tables = module.tables
   topics = module.topics

--- a/app/locals.tf
+++ b/app/locals.tf
@@ -8,7 +8,7 @@ locals {
   vpc = local.dedicated_resources ? module.vpc[0] : data.terraform_remote_state.shared.outputs.dev_vpc
   buckets = var.buckets 
   caches = local.dedicated_resources ? length(var.caches) > 0 ? module.caches[0].caches : {} : try(data.terraform_remote_state.shared.outputs.dev_caches.caches, {})
-  cache_user_id = local.dedicated_resources ? length(var.caches) > 0 ? module.caches[0].iam_user.user_id : "" : try(data.terraform_remote_state.shared.outputs.dev_caches.iam_user.user_id, "")
+  cache_user = local.dedicated_resources ? length(var.caches) > 0 ? module.caches[0].iam_user : {} : try(data.terraform_remote_state.shared.outputs.dev_caches.iam_user, {})
   database = local.dedicated_resources ? var.create_db ? module.databases[0].database : null : try(data.terraform_remote_state.shared.outputs.dev_databases.database, null)
   
   # Network and domain configuration

--- a/deployment/ecs_task.tf
+++ b/deployment/ecs_task.tf
@@ -60,7 +60,7 @@ resource "aws_ecs_task_definition" "app" {
         length(var.caches) > 0 ? [
           {
             name = "CACHE_USER_ID"
-            value = var.cache_user_id
+            value = var.cache_user.user_id
           }
         ] : [],
         var.create_db ? [
@@ -246,7 +246,10 @@ data "aws_iam_policy_document" "task_elasticache_connect_document" {
       "elasticache:Connect"
     ]
 
-    resources = [for cache in var.caches : cache.arn]
+    resources = concat(
+      [for cache in var.caches : cache.arn],
+      [var.cache_user.arn]
+    )
   }
 }
 

--- a/deployment/variables.tf
+++ b/deployment/variables.tf
@@ -132,8 +132,11 @@ variable "caches" {
   }))
 }
 
-variable "cache_user_id" {
-  type = string
+variable "cache_user" {
+  type = object({
+    arn     = string
+    user_id = string
+  })
 }
 
 variable "buckets" {

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.4.0"
+  "version": "v0.4.1"
 }


### PR DESCRIPTION
This one made me spend a bit of time rechecking the config without a clue of what was going on.

The deployment module configures a policy to allow the ECS task to connect to the caches. As opposed to other policies, the cache user needs to be added as a resource, aside from the caches themselves.