### PR TITLE
feat: add the task execution role to the deployment module outputs

### DIFF
--- a/deployment/outputs.tf
+++ b/deployment/outputs.tf
@@ -2,6 +2,10 @@ output "task_definition" {
   value = aws_ecs_task_definition.app
 }
 
+output "task_role" {
+  value = aws_iam_role.ecs_task_role
+}
+
 output "service" {
   value = aws_ecs_service.service
 }

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.4.1"
+  "version": "v0.4.2"
 }


### PR DESCRIPTION
I need the task's role so that I can attach additional policies that grant access to legacy claims resources in the indexing-service.