### PR TITLE
fix: remove reference to unused provider `aws.acm`

### DIFF
--- a/cmd/storoku/template/deploy/app/main.tf
+++ b/cmd/storoku/template/deploy/app/main.tf
@@ -31,12 +31,6 @@ provider "aws" {
   }
 }
 
-# CloudFront is a global service. Certs must be created in us-east-1, where the core ACM infra lives
-provider "aws" {
-  region = "us-east-1"
-  alias = "acm"
-}
-
 {{range .Secrets}}{{if or .Variable .External}}{{else}}
 resource "random_password" "{{.Lower}}" {
   length           = 32
@@ -119,10 +113,6 @@ module "app" {
       object_expiration_days = {{ .ObjectExpirationDays }}{{end}}
     },{{end}}
   ]
-  providers = {
-    aws = aws
-    aws.acm = aws.acm
-  }
   env_files = var.env_files
   domain_base = var.domain_base
 }


### PR DESCRIPTION
closes #32 

It turns out the issue was the explicit reference to the `aws` provider, which was there because of the reference to the `aws.acm` provider. However, the `aws.acm` provider is not needed anymore. It was used by the CloudFront module, which was removed in v0.5.0. 