### PR TITLE
fix: only build and push docker image when applying

### DIFF
--- a/cmd/storoku/template/.github/workflows/terraform.yml
+++ b/cmd/storoku/template/.github/workflows/terraform.yml
@@ -71,9 +71,6 @@ jobs:
         with:
           aws-region: {{"${{ env.AWS_REGION }}"}}
           role-to-assume: arn:aws:iam::{{"${{ env.AWS_ACCOUNT_ID }}"}}:role/terraform-ci
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
         
       - uses: opentofu/setup-opentofu@v1
 
@@ -83,15 +80,22 @@ jobs:
           make init
         working-directory: deploy
 
-      - name: Build + Push Docker ECR
-        run: |
-          make docker-push
-        working-directory: deploy
-
+      # just plan if !inputs.apply
       - name: Terraform Plan
         if: {{"${{ !inputs.apply }}"}}
         run: |
           make plan
+        working-directory: deploy
+
+      # build and push docker image and apply if inputs.apply
+      - name: Set up Docker Buildx
+        if: {{"${{ inputs.apply }}"}}
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build + Push Docker ECR
+        if: {{"${{ inputs.apply }}"}}
+        run: |
+          make docker-push
         working-directory: deploy
 
       - name: Terraform Apply


### PR DESCRIPTION
The terraform workflow file builds and pushes docker images of the service even when we only need to plan. They are not needed for planning, so these changes should make plan jobs run faster.