### PR TITLE
chore: release v0.6.1

### DIFF
--- a/cmd/storoku/template/deploy/app/main.tf
+++ b/cmd/storoku/template/deploy/app/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.86.0"
+      version = ">= 6.0.0"
     }
     archive = {
       source = "hashicorp/archive"

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.6.0"
+  "version": "v0.6.1"
 }


### PR DESCRIPTION
Release v0.6.1 and a drive-by fix that I missed on a previous PR.