### PR TITLE
fix: treat forge-test as a production environment

### DIFF
--- a/app/locals.tf
+++ b/app/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  is_production = var.environment == "prod" || startswith(var.environment, "prod-") || endswith(var.environment, "-prod")
+  is_production = var.environment == "prod" || startswith(var.environment, "prod-") || endswith(var.environment, "-prod") || var.environment == "forge-test"
   is_staging = var.environment == "staging" || startswith(var.environment, "staging-") || endswith(var.environment, "-staging")
 
   # Only prod and staging get their own resources. All other envs will share the dev shared infra


### PR DESCRIPTION
Ref. https://github.com/storacha/project-tracking/issues/667

We decided to re-use the test network as our demo network in the terms specified in https://github.com/storacha/RFC/pull/82.

As the demo network, resources and configuration will resemble those of the production network.